### PR TITLE
fix: fix channels having a higher level than currently available

### DIFF
--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -52,7 +52,7 @@ export async function handleMessageCreate(message: Message): Promise<void> {
 
 	const thread = await message.startThread({
 		name: `${authorName} (${creationDate})`,
-		autoArchiveDuration: channel.defaultAutoArchiveDuration,
+		autoArchiveDuration: 'MAX',
 	});
 
 	const closeButton = new MessageButton()


### PR DESCRIPTION
Fixes #23 

Seems like Discord.js has a "MAX" option that reads the features. I have not tested, but this should always work. Hopefully. I pray. In God I Trust.