### PR TITLE
✨ Purge configuration data of removed guilds

### DIFF
--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -1,4 +1,4 @@
-import { Guild } from "discord.js";
+import { Client, Guild } from "discord.js";
 import * as defaultConfig from "../config.json";
 import { resolve as pathResolve } from "path";
 import * as fs from "fs";
@@ -77,6 +77,22 @@ export function resetConfigToDefault(guildId: string): boolean {
 	fs.rmSync(path);
 	guildConfigsCache.delete(guildId);
 	return true;
+}
+
+export function deleteConfigsFromUnkownServers(client: Client): void {
+	if (!client.guilds.cache.size) {
+		console.warn("No guilds available; skipping config deletion.");
+		return;
+	}
+
+	const configFiles = fs.readdirSync(CONFIGS_PATH);
+	configFiles.forEach(file => {
+		const guildId = file.split(".")[0];
+		if (!client.guilds.cache.has(guildId)) {
+			resetConfigToDefault(guildId);
+			console.log(`Deleted config for guild ${guildId}`);
+		}
+	});
 }
 
 function readConfigFromFile(guildId: string): NeedleConfig | undefined {

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -76,6 +76,7 @@ export function resetConfigToDefault(guildId: string): boolean {
 	if (!fs.existsSync(path)) return false;
 	fs.rmSync(path);
 	guildConfigsCache.delete(guildId);
+	console.log(`Deleted data for guild ${guildId}`);
 	return true;
 }
 
@@ -90,7 +91,6 @@ export function deleteConfigsFromUnkownServers(client: Client): void {
 		const guildId = file.split(".")[0];
 		if (!client.guilds.cache.has(guildId)) {
 			resetConfigToDefault(guildId);
-			console.log(`Deleted config for guild ${guildId}`);
 		}
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,8 @@
 import { Client, Intents } from "discord.js";
-import { resolve as pathResolve } from "path";
-import { readdirSync } from "fs";
 import { getOrLoadAllCommands } from "./handlers/commandHandler";
 import { handleInteractionCreate } from "./handlers/interactionHandler";
 import { handleMessageCreate } from "./handlers/messageHandler";
-import { getApiToken, resetConfigToDefault } from "./helpers/configHelpers";
-
-const CONFIGS_PATH = pathResolve(__dirname, "../configs");
+import { deleteConfigsFromUnkownServers, getApiToken, resetConfigToDefault } from "./helpers/configHelpers";
 
 (async () => {
 	(await import("dotenv")).config();
@@ -17,20 +13,7 @@ const CONFIGS_PATH = pathResolve(__dirname, "../configs");
 	const CLIENT = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 	CLIENT.once("ready", () => {
 		console.log("Ready!");
-
-		if (!CLIENT.guilds.cache.size) {
-			console.warn("No guilds available; skipping config deletion.");
-			return;
-		}
-
-		const files = readdirSync(CONFIGS_PATH);
-		files.forEach(file => {
-			const id = file.split(".")[0];
-			if (!CLIENT.guilds.cache.has(id)) {
-				resetConfigToDefault(id);
-				console.log(`Deleted config for guild ${id}`);
-			}
-		});
+		deleteConfigsFromUnkownServers(CLIENT);
 	});
 
 	CLIENT.on("interactionCreate", interaction => handleInteractionCreate(interaction).catch(e => console.log(e)));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import { Client, Intents } from "discord.js";
+import { resolve as pathResolve } from "path";
+import { readdirSync } from "fs";
 import { getOrLoadAllCommands } from "./handlers/commandHandler";
 import { handleInteractionCreate } from "./handlers/interactionHandler";
 import { handleMessageCreate } from "./handlers/messageHandler";
-import { getApiToken } from "./helpers/configHelpers";
+import { getApiToken, resetConfigToDefault } from "./helpers/configHelpers";
+
+const CONFIGS_PATH = pathResolve(__dirname, "../configs");
 
 (async () => {
 	(await import("dotenv")).config();
@@ -11,10 +15,30 @@ import { getApiToken } from "./helpers/configHelpers";
 	await getOrLoadAllCommands(false);
 
 	const CLIENT = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
-	CLIENT.once("ready", () => console.log("Ready!"));
+	CLIENT.once("ready", () => {
+		console.log("Ready!");
+
+		if (!CLIENT.guilds.cache.size) {
+			console.warn("No guilds available; skipping config deletion.");
+			return;
+		}
+
+		const files = readdirSync(CONFIGS_PATH);
+		files.forEach(file => {
+			const id = file.split(".")[0];
+			if (!CLIENT.guilds.cache.has(id)) {
+				resetConfigToDefault(id);
+				console.log(`Deleted config for guild ${id}`);
+			}
+		});
+	});
 
 	CLIENT.on("interactionCreate", interaction => handleInteractionCreate(interaction).catch(e => console.log(e)));
 	CLIENT.on("messageCreate", message => handleMessageCreate(message).catch(e => console.log(e)));
+	CLIENT.on("guildDelete", guild => {
+		resetConfigToDefault(guild.id);
+		console.log(`Deleted data for guild ${guild.id}`);
+	});
 
 	CLIENT.login(getApiToken() ?? undefined);
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,7 @@ import { deleteConfigsFromUnkownServers, getApiToken, resetConfigToDefault } fro
 
 	CLIENT.on("interactionCreate", interaction => handleInteractionCreate(interaction).catch(e => console.log(e)));
 	CLIENT.on("messageCreate", message => handleMessageCreate(message).catch(e => console.log(e)));
-	CLIENT.on("guildDelete", guild => {
-		resetConfigToDefault(guild.id);
-		console.log(`Deleted data for guild ${guild.id}`);
-	});
+	CLIENT.on("guildDelete", guild => { resetConfigToDefault(guild.id); });
 
 	CLIENT.login(getApiToken() ?? undefined);
 })();


### PR DESCRIPTION
When Needle is removed from a guild (kicked, guild deleted, etc.), it will now delete the configuration data of that guild.

On startup, Needle will compare the configs directory to its current guilds, deleting ones it's no longer in. This is done in case Needle is offline when the `guildDelete` event fires. As a precautionary measure, Needle will not delete configs if no guilds are present; this protects against the wrong token being used by mistake, or a theoretical Discord API error. 

Both of these things are achieved through the `resetConfigToDefault` function, which just deletes the respective file.

- Closes #36