### PR TITLE
✨ Custom config directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DISCORD_API_TOKEN=
+CLIENT_ID=
+GUILD_ID=
+# This is relative to Needle's root directory, and defaults to "configs"
+CONFIGS_PATH=

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <div align="center">
    <h1>
       <sub>
@@ -13,26 +11,24 @@
 </div>
 
 ## Self-hosting
+
 This step-by-step guide assumes you have [NodeJS](https://nodejs.org/en/) version `16.9.0` or higher installed and that you have a Discord Bot user set up at [Discord's developer page](https://discord.com/developers/applications) that has been invited to your server with the scopes `applications.commands` and `bot`.
 
 1. Fork and clone the repository
-2. Create a file named `.env`  in the root directory and insert your bot's Discord API token and Application ID:
-   ```bash
-   DISCORD_API_TOKEN=abcd1234...
-   CLIENT_ID=123456...
-   ```
+2. Copy `.env.example` to `.env` and insert your bot's Discord API token and Application ID.
 3. Run `npm install`
 4. Run `npm run deploy`. This will make the slash commands show up in the servers the bot are in, but **it can take up to _ONE HOUR_ before they show up**.
 5. Make sure the bot has the required permissions in Discord:
-   - [x] View channels
-   - [x] Send messages
-   - [x] Send messages in threads
-   - [x] Create public threads
-   - [x] Read message history
+    - [x] View channels
+    - [x] Send messages
+    - [x] Send messages in threads
+    - [x] Create public threads
+    - [x] Read message history
 6. Run `npm start`
 7. Deploy! :tada:
 
 ## Contributing
+
 Coming soon :tm:
 
 [Join the Discord](https://needle.gg/chat) if interested!

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -22,7 +22,7 @@ import * as fs from "fs";
 import type { NeedleConfig } from "../types/needleConfig";
 import { MessageKey } from "./messageHelpers";
 
-const CONFIGS_PATH = pathResolve(__dirname, "../../configs");
+const CONFIGS_PATH = pathResolve(__dirname, "../../", process.env.CONFIGS_PATH || "configs");
 const guildConfigsCache = new Map<string, NeedleConfig>();
 
 export function getConfig(guildId = ""): NeedleConfig {

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -127,19 +127,16 @@ export function deleteConfigsFromUnkownServers(client: Client): void {
 		return;
 	}
 
-	try {
-		const configFiles = fs.readdirSync(CONFIGS_PATH);
-		configFiles.forEach(file => {
-			const guildId = file.split(".")[0];
-			if (!client.guilds.cache.has(guildId)) {
-				resetConfigToDefault(guildId);
-			}
-		});
-	}
-	catch {
-		// Configs directory not present
-		return;
-	}
+	if (!fs.existsSync(CONFIGS_PATH)) return;
+
+	const configFiles = fs.readdirSync(CONFIGS_PATH);
+	configFiles.forEach(file => {
+		const guildId = file.split(".")[0];
+		if (!client.guilds.cache.has(guildId)) {
+			resetConfigToDefault(guildId);
+		}
+	});
+}
 }
 
 function readConfigFromFile(guildId: string): NeedleConfig | undefined {

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -137,7 +137,6 @@ export function deleteConfigsFromUnkownServers(client: Client): void {
 		}
 	});
 }
-}
 
 function readConfigFromFile(guildId: string): NeedleConfig | undefined {
 	const path = getGuildConfigPath(guildId);

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -127,13 +127,19 @@ export function deleteConfigsFromUnkownServers(client: Client): void {
 		return;
 	}
 
-	const configFiles = fs.readdirSync(CONFIGS_PATH);
-	configFiles.forEach(file => {
-		const guildId = file.split(".")[0];
-		if (!client.guilds.cache.has(guildId)) {
-			resetConfigToDefault(guildId);
-		}
-	});
+	try {
+		const configFiles = fs.readdirSync(CONFIGS_PATH);
+		configFiles.forEach(file => {
+			const guildId = file.split(".")[0];
+			if (!client.guilds.cache.has(guildId)) {
+				resetConfigToDefault(guildId);
+			}
+		});
+	}
+	catch {
+		// Configs directory not present
+		return;
+	}
 }
 
 function readConfigFromFile(guildId: string): NeedleConfig | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@
 // If not, see <https://www.gnu.org/licenses/>.
 //
 // ________________________________________________________________________________________________
+import * as dotenv from "dotenv";
+dotenv.config();
 
 import { Client, Intents } from "discord.js";
 import { getOrLoadAllCommands } from "./handlers/commandHandler";
@@ -39,8 +41,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 `);
 
 (async () => {
-	(await import("dotenv")).config();
-
 	// Initial load of all commands
 	await getOrLoadAllCommands(false);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@
 // If not, see <https://www.gnu.org/licenses/>.
 //
 // ________________________________________________________________________________________________
-import * as dotenv from "dotenv";
-dotenv.config();
+import { config } from "dotenv";
+config();
 
 import { Client, Intents } from "discord.js";
 import { getOrLoadAllCommands } from "./handlers/commandHandler";


### PR DESCRIPTION
This pull request allows the config directory to be changed using the `CONFIGS_PATH` environmental variable. If not specified, it defaults to `configs`, making it backward-compatible. It's relative to Needle's root directory.

Additionally, this pull request
- Moves `dotenv` setup to the top of `index.ts`. Other files could be loaded *before* env variables were setup because it was in an async function.
- Returns from `deleteConfigsFromUnkownServers()` if the directory doesn't exist.
- Creates `.env.example`, and modifies `README.md` to mention it.