### PR TITLE
✏️ Fixed typo in function name

### DIFF
--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -121,7 +121,7 @@ export function resetConfigToDefault(guildId: string): boolean {
 	return true;
 }
 
-export function deleteConfigsFromUnkownServers(client: Client): void {
+export function deleteConfigsFromUnknownServers(client: Client): void {
 	if (!client.guilds.cache.size) {
 		console.warn("No guilds available; skipping config deletion.");
 		return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { Client, Intents } from "discord.js";
 import { getOrLoadAllCommands } from "./handlers/commandHandler";
 import { handleInteractionCreate } from "./handlers/interactionHandler";
 import { handleMessageCreate } from "./handlers/messageHandler";
-import { deleteConfigsFromUnkownServers, getApiToken, resetConfigToDefault } from "./helpers/configHelpers";
+import { deleteConfigsFromUnknownServers, getApiToken, resetConfigToDefault } from "./helpers/configHelpers";
 
 console.log(`Needle, a Discord bot that declutters your server by creating threads
 Copyright (C) 2022  Marcus Otterström
@@ -59,7 +59,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	CLIENT.once("ready", () => {
 		console.log("Ready!");
-		deleteConfigsFromUnkownServers(CLIENT);
+		deleteConfigsFromUnknownServers(CLIENT);
 	});
 
 	CLIENT.on("interactionCreate", interaction => handleInteractionCreate(interaction).catch(e => console.log(e)));


### PR DESCRIPTION
This pull request renames `deleteConfigsFromUnkownServers()` to `deleteConfigsFromUnknownServers()`, fixing the typo.