### PR TITLE
✏️ Remove prefix from issue titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,10 +1,9 @@
 ---
 name: "\U0001F41B Bug report"
 about: Report a possible issue or bug
-title: "\U0001F41B BUG: "
+title: "\U0001F41B "
 labels: "potential bug \U0001F41B"
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Write '....'
@@ -24,9 +24,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **System specifications (please complete the following information if applicable):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+-   OS: [e.g. iOS]
+-   Browser [e.g. chrome, safari]
+-   Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/---improvement.md
+++ b/.github/ISSUE_TEMPLATE/---improvement.md
@@ -1,10 +1,9 @@
 ---
 name: "\U0001F4A1 Improvement"
 about: Suggest an improvement for this project
-title: "\U0001F4A1 Improvement: "
+title: "\U0001F4A1 "
 labels: "improvement \U0001F4A1"
-assignees: ''
-
+assignees: ""
 ---
 
 **Is your request for improvement related to a problem? Please describe.**


### PR DESCRIPTION
This pull request removes the `BUG:` and `Improvement:` prefixes from the issue template titles, as discussed in #73 and on Needle's Discord server.

This reduces visual noise. The emoji and label already show the type of issue, making the prefix redundant.