### PR TITLE
✨ Auto-thread slowmode option

### DIFF
--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -212,9 +212,16 @@ async function configureAutothreading(interaction: CommandInteraction): Promise<
 	if (!clientUser) return interactionReply(interaction, getMessage("ERR_UNKNOWN"));
 
 	const botMember = await interaction.guild.members.fetch(clientUser);
-	if (!botMember.permissionsIn(channel.id).has(Permissions.FLAGS.VIEW_CHANNEL)) {
-		addMessageContext({ channel: channel });
+	const botPermissions = botMember.permissionsIn(channel.id);
+
+	if (!botPermissions.has(Permissions.FLAGS.VIEW_CHANNEL)) {
+		addMessageContext({ channel });
 		return interactionReply(interaction, getMessage("ERR_CHANNEL_VISIBILITY"));
+	}
+
+	if (!botPermissions.has(Permissions.FLAGS.MANAGE_THREADS)) {
+		addMessageContext({ channel });
+		return interactionReply(interaction, getMessage("ERR_CHANNEL_SLOWMODE"));
 	}
 
 	if (enabled) {

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -95,6 +95,18 @@ export const command: NeedleCommand = {
 					})
 					.addStringOption(option => {
 						return option
+							.setName("slowmode")
+							.setDescription("The default slowmode option for new threads")
+							.addChoice("Off (DEFAULT)", "0")
+							.addChoice("30 seconds", "30")
+							.addChoice("1 minute", "60")
+							.addChoice("5 minutes", "300")
+							.addChoice("15 minutes", "900")
+							.addChoice("1 hour", "3600")
+							.addChoice("6 hours", "21600");
+					})
+					.addStringOption(option => {
+						return option
 							.setName("custom-message")
 							.setDescription("The message to send when a thread is created (\"\\n\" for new line)");
 					});
@@ -186,6 +198,7 @@ async function configureAutothreading(interaction: CommandInteraction): Promise<
 	const customMessage = interaction.options.getString("custom-message") ?? "";
 	const archiveImmediately = interaction.options.getString("archive-behavior") !== "slow";
 	const includeBots = interaction.options.getBoolean("include-bots") ?? false;
+	const slowmode = parseInt(interaction.options.getString("slowmode") ?? "0");
 
 	if (!interaction.guild || !interaction.guildId) {
 		return interactionReply(interaction, getMessage("ERR_ONLY_IN_SERVER"));
@@ -205,7 +218,7 @@ async function configureAutothreading(interaction: CommandInteraction): Promise<
 	}
 
 	if (enabled) {
-		const success = enableAutothreading(interaction.guild, channel.id, includeBots, archiveImmediately, customMessage);
+		const success = enableAutothreading(interaction.guild, channel.id, includeBots, archiveImmediately, customMessage, slowmode);
 		return success
 			? interactionReply(interaction, `Updated auto-threading settings for <#${channel.id}>`, false)
 			: interactionReply(interaction, getMessage("ERR_UNKNOWN"));

--- a/src/config.json
+++ b/src/config.json
@@ -1,23 +1,24 @@
 {
-    "threadChannels": [],
-    "emojisEnabled": true,
-    "messages": {
-        "ERR_UNKNOWN": "An unexpected error occurred. Please try again later.",
-        "ERR_ONLY_IN_SERVER": "You can only perform this action inside a server.",
-        "ERR_ONLY_IN_THREAD": "You can only perform this action inside a thread.",
-        "ERR_ONLY_THREAD_OWNER": "You need to be the thread owner to perform this action.",
-        "ERR_NO_EFFECT": "This action will have no effect.",
-        "ERR_JSON_MISSING": "The JSON content was missing.",
-        "ERR_JSON_INVALID": "Your input was not valid JSON. You can use an online tool such as <https://onlinejsontools.com/validate-json> to validate your json.",
-        "ERR_CONFIG_INVALID": "Your config was invalid. Remember to: \n- Pass minified JSON, because new lines inside commands does not work in Discord. You can use an online tool such as <https://onlinejsontools.com/minify-json> for minification.\n- Wrap the config in an object. \n- Spell property keys correctly.\n\nIf you need help with the formatting, you can see the default config of Needle at <https://github.com/MarcusOtter/discord-needle/blob/main/src/config.json>. Changes to `discordApiToken` and `dev` will be ignored by this command.",
-        "ERR_DURATION_INVALID": "The specified duration was invalid.",
-        "ERR_PARAMETER_MISSING": "A non-optional parameter is missing from the command.",
-        "ERR_INSUFFICIENT_PERMS": "You do not have permission to perform this action.",
-        "ERR_CHANNEL_VISIBILITY": "The $CHANNEL channel is not visible to the bot. Change the permissions and try again.",
-        "ERR_AMBIGUOUS_THREAD_AUTHOR": "Could not determine the author of this thread, because the initial message was missing.",
+	"threadChannels": [],
+	"emojisEnabled": true,
+	"messages": {
+		"ERR_UNKNOWN": "An unexpected error occurred. Please try again later.",
+		"ERR_ONLY_IN_SERVER": "You can only perform this action inside a server.",
+		"ERR_ONLY_IN_THREAD": "You can only perform this action inside a thread.",
+		"ERR_ONLY_THREAD_OWNER": "You need to be the thread owner to perform this action.",
+		"ERR_NO_EFFECT": "This action will have no effect.",
+		"ERR_JSON_MISSING": "The JSON content was missing.",
+		"ERR_JSON_INVALID": "Your input was not valid JSON. You can use an online tool such as <https://onlinejsontools.com/validate-json> to validate your json.",
+		"ERR_CONFIG_INVALID": "Your config was invalid. Remember to: \n- Pass minified JSON, because new lines inside commands does not work in Discord. You can use an online tool such as <https://onlinejsontools.com/minify-json> for minification.\n- Wrap the config in an object. \n- Spell property keys correctly.\n\nIf you need help with the formatting, you can see the default config of Needle at <https://github.com/MarcusOtter/discord-needle/blob/main/src/config.json>. Changes to `discordApiToken` and `dev` will be ignored by this command.",
+		"ERR_DURATION_INVALID": "The specified duration was invalid.",
+		"ERR_PARAMETER_MISSING": "A non-optional parameter is missing from the command.",
+		"ERR_INSUFFICIENT_PERMS": "You do not have permission to perform this action.",
+		"ERR_CHANNEL_VISIBILITY": "The $CHANNEL channel is not visible to the bot. Change the permissions and try again.",
+		"ERR_CHANNEL_SLOWMODE": "The bot does not have permissions to Manage Threads in $CHANNEL. Change the permissions and try again.",
+		"ERR_AMBIGUOUS_THREAD_AUTHOR": "Could not determine the author of this thread, because the initial message was missing.",
 
-        "SUCCESS_THREAD_CREATE": "Thread automatically created by $USER in $CHANNEL.",
-        "SUCCESS_THREAD_ARCHIVE_IMMEDIATE": "Thread was archived by $USER. Anyone can send a message to unarchive it.",
-        "SUCCESS_THREAD_ARCHIVE_SLOW": "This thread will be archived automatically after 1 hour of inactivity as requested by $USER."
-    }
+		"SUCCESS_THREAD_CREATE": "Thread automatically created by $USER in $CHANNEL.",
+		"SUCCESS_THREAD_ARCHIVE_IMMEDIATE": "Thread was archived by $USER. Anyone can send a message to unarchive it.",
+		"SUCCESS_THREAD_ARCHIVE_SLOW": "This thread will be archived automatically after 1 hour of inactivity as requested by $USER."
+	}
 }

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -16,7 +16,7 @@
 // ________________________________________________________________________________________________
 
 import { type Message, MessageActionRow, MessageButton, NewsChannel, TextChannel, ThreadChannel } from "discord.js";
-import { emojisEnabled, getConfig, includeBotsForAutothread } from "../helpers/configHelpers";
+import { emojisEnabled, getConfig, includeBotsForAutothread, getSlowmodeSeconds } from "../helpers/configHelpers";
 import { getMessage, resetMessageContext, addMessageContext, isAutoThreadChannel, getHelpButton, replaceMessageVariables, getThreadAuthor } from "../helpers/messageHelpers";
 import { getRequiredPermissions, getSafeDefaultAutoArchiveDuration } from "../helpers/permissionHelpers";
 
@@ -99,8 +99,11 @@ async function autoCreateThread(message: Message) {
 		? `🆕 ${authorName} (${creationDate})`
 		: `${authorName} (${creationDate})`;
 
+	const slowmode = getSlowmodeSeconds(guild.id, channel.id);
+
 	const thread = await message.startThread({
 		name,
+		rateLimitPerUser: slowmode,
 		autoArchiveDuration: getSafeDefaultAutoArchiveDuration(channel),
 	});
 

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -69,9 +69,11 @@ async function autoCreateThread(message: Message) {
 	if (message.hasThread) return;
 	if (!isAutoThreadChannel(channel.id, guild.id)) return;
 
+	const slowmode = getSlowmodeSeconds(guild.id, channel.id);
+
 	const botMember = await guild.members.fetch(message.client.user);
 	const botPermissions = botMember.permissionsIn(message.channel.id);
-	const requiredPermissions = getRequiredPermissions();
+	const requiredPermissions = getRequiredPermissions(slowmode);
 	if (!botPermissions.has(requiredPermissions)) {
 		try {
 			const missing = botPermissions.missing(requiredPermissions);
@@ -98,8 +100,6 @@ async function autoCreateThread(message: Message) {
 	const name = emojisEnabled(guild)
 		? `🆕 ${authorName} (${creationDate})`
 		: `${authorName} (${creationDate})`;
-
-	const slowmode = getSlowmodeSeconds(guild.id, channel.id);
 
 	const thread = await message.startThread({
 		name,

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -83,7 +83,12 @@ export function setMessage(guild: Guild, messageKey: MessageKey, value: string):
 	return setConfig(guild, config);
 }
 
-export function enableAutothreading(guild: Guild, channelId: string, includeBots?: boolean, archiveImmediately?: boolean, messageContent?: string): boolean {
+export function getSlowmodeSeconds(guildId: string, channelId: string) {
+	const config = getConfig(guildId);
+	return config?.threadChannels?.find(x => x.channelId === channelId)?.slowmode ?? 0;
+}
+
+export function enableAutothreading(guild: Guild, channelId: string, includeBots?: boolean, archiveImmediately?: boolean, messageContent?: string, slowmode?: number): boolean {
 	const config = getConfig(guild.id);
 	if (!config || !config.threadChannels) { return false; }
 	if ((messageContent?.length ?? 0) > 2000) { return false; }
@@ -93,9 +98,10 @@ export function enableAutothreading(guild: Guild, channelId: string, includeBots
 		if (includeBots !== undefined) config.threadChannels[index].includeBots = includeBots;
 		if (archiveImmediately !== undefined) config.threadChannels[index].archiveImmediately = archiveImmediately;
 		if (messageContent !== undefined) config.threadChannels[index].messageContent = messageContent;
+		if (slowmode !== undefined) config.threadChannels[index].slowmode = slowmode;
 	}
 	else {
-		config.threadChannels.push({ channelId, includeBots, archiveImmediately, messageContent });
+		config.threadChannels.push({ channelId, includeBots, archiveImmediately, messageContent, slowmode });
 	}
 	return setConfig(guild, config);
 }

--- a/src/helpers/permissionHelpers.ts
+++ b/src/helpers/permissionHelpers.ts
@@ -17,7 +17,7 @@
 
 import { type GuildMember, type NewsChannel, Permissions, type TextChannel, type ThreadAutoArchiveDuration } from "discord.js";
 
-export function getRequiredPermissions(): bigint[] {
+export function getRequiredPermissions(slowmode?: number): bigint[] {
 	const output = [
 		Permissions.FLAGS.VIEW_CHANNEL,
 		Permissions.FLAGS.SEND_MESSAGES,
@@ -25,6 +25,10 @@ export function getRequiredPermissions(): bigint[] {
 		Permissions.FLAGS.CREATE_PUBLIC_THREADS,
 		Permissions.FLAGS.READ_MESSAGE_HISTORY,
 	];
+
+	if (slowmode && slowmode > 0) {
+		output.push(Permissions.FLAGS.MANAGE_THREADS);
+	}
 
 	return output;
 }

--- a/src/types/needleConfig.ts
+++ b/src/types/needleConfig.ts
@@ -27,6 +27,7 @@ export interface NeedleConfig {
         ERR_PARAMETER_MISSING?: string,
         ERR_INSUFFICIENT_PERMS?: string,
         ERR_CHANNEL_VISIBILITY?: string,
+		ERR_CHANNEL_SLOWMODE?: string,
         ERR_AMBIGUOUS_THREAD_AUTHOR?: string,
 
         SUCCESS_THREAD_CREATE?: string,

--- a/src/types/needleConfig.ts
+++ b/src/types/needleConfig.ts
@@ -40,4 +40,5 @@ export interface AutothreadChannelConfig {
     archiveImmediately?: boolean,
     messageContent?: string,
     includeBots?: boolean,
+	slowmode?: number,
 }


### PR DESCRIPTION
This pull request adds `slowmode` option to `/configure auto-threading` with the possible options:

- Off (DEFAULT)
- 5 seconds
- 30 seconds
- 1 minute
- 5 minutes
- 15 minutes
- 1 hour
- 6 hours

This option is used as an auto-thread's default slowmode.

The value for each option in the dropdown menu is the corresponding seconds as a string. This is converted & stored as a number in `configureAutothreading()`.