### PR TITLE
🏗️ Destroy client on SIGINT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,5 +67,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 	CLIENT.on("guildDelete", guild => { resetConfigToDefault(guild.id); });
 
 	CLIENT.login(getApiToken());
+
+	process.on("SIGINT", () => {
+		CLIENT.destroy();
+		console.log("Destroyed client");
+		process.exit(0);
+	});
 })();
 


### PR DESCRIPTION
Currently, when Needle's process is closed, it's Discord bot will stay online & keep accepting requests until Discord times it out.

This pull request destroys the client & logs out Needle upon a `SIGINT`.