### PR TITLE
🩹 Remove "Success!" message

### DIFF
--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -71,7 +71,7 @@ export const command: NeedleCommand = {
 		async function archiveThread(thread: ThreadChannel): Promise<void> {
 			if (shouldArchiveImmediately(thread)) {
 				if (interaction.isButton()) {
-					await interaction.update({ components: [] });
+					await interaction.update({ content: interaction.message.content });
 					const message = getMessage("SUCCESS_THREAD_ARCHIVE_IMMEDIATE");
 					if (message) {
 						await thread.send(message);

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -94,7 +94,7 @@ export const command: NeedleCommand = {
 			await thread.setAutoArchiveDuration(60);
 
 			if (interaction.isButton()) {
-				await interactionReply(interaction, "Success!");
+				await interaction.update({ content: interaction.message.content });
 				const message = getMessage("SUCCESS_THREAD_ARCHIVE_SLOW");
 				if (message) {
 					await thread.send(message);

--- a/src/commands/close.ts
+++ b/src/commands/close.ts
@@ -71,7 +71,7 @@ export const command: NeedleCommand = {
 		async function archiveThread(thread: ThreadChannel): Promise<void> {
 			if (shouldArchiveImmediately(thread)) {
 				if (interaction.isButton()) {
-					await interactionReply(interaction, "Success!");
+					await interaction.update({ components: [] });
 					const message = getMessage("SUCCESS_THREAD_ARCHIVE_IMMEDIATE");
 					if (message) {
 						await thread.send(message);


### PR DESCRIPTION
This pull request removes the "Success!" button sent when clicking on the **Archive Thread** button.

Normally, interactions must be responded to with a message. However, button interactions are unique; editing the original message counts as a response.

This is accomplished by simply removing the buttons from the original button when clicked.