### PR TITLE
🐛 Give build action package scope

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     release:
         types: [published]
 
+permissions:
+    packages: write
+
 jobs:
     docker:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Users that had write access to a branch, but not the repository itself (eg. Dependabot), couldn't push Docker images to GHCR. This PR fixes that.