### PR TITLE
Lowercase docker image name and bump version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   needle:
-    image: ghcr.io/marcusotter/discord-needle:2.1.0
+    image: ghcr.io/marcusotter/discord-needle:stable
     restart: unless-stopped
     environment:
       - DISCORD_API_TOKEN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   needle:
-    image: ghcr.io/MarcusOtter/discord-needle:2.0.0
+    image: ghcr.io/marcusotter/discord-needle:2.1.0
     restart: unless-stopped
     environment:
       - DISCORD_API_TOKEN=


### PR DESCRIPTION
A person on Discord was having trouble self-hosting with docker, [see conversation here](https://ptb.discord.com/channels/888952043048415232/888968915085054012/964810738952716288).
This fixes the `invalid reference format: repository name must be lowercase` problem and bumps the version of Needle.

Side question: is there a better way to write this compose file so we don't have to update it on every new version? Can we just point it to `:stable`?