### PR TITLE
Remove boost requirement

### DIFF
--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -34,7 +34,7 @@ import {
 	replaceMessageVariables,
 	getThreadAuthor,
 } from "../helpers/messageHelpers";
-import { getRequiredPermissions, getSafeDefaultAutoArchiveDuration } from "../helpers/permissionHelpers";
+import { getRequiredPermissions } from "../helpers/permissionHelpers";
 
 export async function handleMessageCreate(message: Message): Promise<void> {
 	// Server outage
@@ -118,7 +118,7 @@ async function autoCreateThread(message: Message, requestId: Snowflake) {
 	const thread = await message.startThread({
 		name,
 		rateLimitPerUser: slowmode,
-		autoArchiveDuration: getSafeDefaultAutoArchiveDuration(channel),
+		autoArchiveDuration: channel.defaultAutoArchiveDuration ?? 1440, // 24h
 	});
 
 	const closeButton = new MessageButton()
@@ -134,6 +134,7 @@ async function autoCreateThread(message: Message, requestId: Snowflake) {
 	const overrideMessageContent = getConfig(guild.id).threadChannels?.find(
 		x => x?.channelId === channel.id
 	)?.messageContent;
+
 	const msgContent = overrideMessageContent
 		? replaceMessageVariables(overrideMessageContent, requestId)
 		: getMessage("SUCCESS_THREAD_CREATE", requestId);

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -35,6 +35,7 @@ import {
 	getThreadAuthor,
 } from "../helpers/messageHelpers";
 import { getRequiredPermissions } from "../helpers/permissionHelpers";
+import { wait } from "../helpers/promiseHelpers";
 
 export async function handleMessageCreate(message: Message): Promise<void> {
 	// Server outage
@@ -147,6 +148,7 @@ async function autoCreateThread(message: Message, requestId: Snowflake) {
 
 		if (botMember.permissionsIn(thread.id).has(Permissions.FLAGS.MANAGE_MESSAGES)) {
 			await msg.pin();
+			await wait(50); // Let's wait a few ms here to ensure the latest message is actually the pin message
 			await thread.lastMessage?.delete();
 		}
 	}

--- a/src/helpers/permissionHelpers.ts
+++ b/src/helpers/permissionHelpers.ts
@@ -13,13 +13,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/>.
 */
 
-import {
-	type GuildMember,
-	type NewsChannel,
-	Permissions,
-	type TextChannel,
-	type ThreadAutoArchiveDuration,
-} from "discord.js";
+import { type GuildMember, Permissions } from "discord.js";
 
 export function getRequiredPermissions(slowmode?: number): bigint[] {
 	const output = [
@@ -43,21 +37,4 @@ export function memberIsModerator(member: GuildMember): boolean {
 
 export function memberIsAdmin(member: GuildMember): boolean {
 	return member.permissions.has(Permissions.FLAGS.ADMINISTRATOR);
-}
-
-// Fixes https://github.com/MarcusOtter/discord-needle/issues/23
-// Should not be required, but Discord for some reason allows the default duration to be higher than the allowed value
-export function getSafeDefaultAutoArchiveDuration(channel: TextChannel | NewsChannel): ThreadAutoArchiveDuration {
-	const archiveDuration = channel.defaultAutoArchiveDuration;
-	if (!archiveDuration || archiveDuration === "MAX") return "MAX";
-
-	const highest = getHighestAllowedArchiveDuration(channel);
-	return archiveDuration > highest ? highest : archiveDuration;
-}
-
-function getHighestAllowedArchiveDuration(channel: TextChannel | NewsChannel) {
-	if (channel.guild.features.includes("SEVEN_DAY_THREAD_ARCHIVE")) return 10080;
-	if (channel.guild.features.includes("THREE_DAY_THREAD_ARCHIVE")) return 4320;
-
-	return 1440; // 1d
 }

--- a/src/helpers/promiseHelpers.ts
+++ b/src/helpers/promiseHelpers.ts
@@ -1,0 +1,3 @@
+export function wait(milliseconds: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
Removes the boost requirement for auto-archive duration and fixes a bug with the pin message features that I found during testing

Closes #115
Closes #156
Closes #157