### PR TITLE
Add keyword for not sending any message and buttons only

### DIFF
--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -125,7 +125,7 @@ export const command: NeedleCommand = {
 					.addStringOption(option => {
 						return option
 							.setName("custom-message")
-							.setDescription('The message to send when a thread is created ("\\n" for new line)');
+							.setDescription('The message to send when a thread is created (Set to $NONE to send no message and $BUTTONS for buttons only)');
 					});
 			})
 			.addSubcommand(subcommand => {

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -141,15 +141,22 @@ async function autoCreateThread(message: Message, requestId: Snowflake) {
 		: getMessage("SUCCESS_THREAD_CREATE", requestId);
 
 	if (msgContent && msgContent.length > 0) {
-		const msg = await thread.send({
+		const msgObject = { 
 			content: msgContent,
 			components: [buttonRow],
-		});
+		};
 
-		if (botMember.permissionsIn(thread.id).has(Permissions.FLAGS.MANAGE_MESSAGES)) {
-			await msg.pin();
-			await wait(50); // Let's wait a few ms here to ensure the latest message is actually the pin message
-			await thread.lastMessage?.delete();
+		if (msgObject.content != "$NONE") {
+			if (msgObject.content === "$BUTTONS")
+				msgObject.content = "\n";
+	
+			const msg = await thread.send(msgObject);
+
+			if (botMember.permissionsIn(thread.id).has(Permissions.FLAGS.MANAGE_MESSAGES)) {
+				await msg.pin();
+				await wait(50); // Let's wait a few ms here to ensure the latest message is actually the pin message
+				await thread.lastMessage?.delete();
+			}
 		}
 	}
 


### PR DESCRIPTION
As discussed on Discord, add a way to make Needle not send any message after autothreading. While I was at it, I figured adding a keyword to show buttons only would make sense as well.

Set `custom-message` to `$NONE` and Needle won't send any message, setting to `$BUTTONS` will only show buttons (similar to setting to `\n`, which also still works).

I thought about where it would make the most sense to make changes, but considering changing `messageHandler.ts` was a requirement anyway, I didn't it was worth doing it another way, but feel free to edit this PR if there is a cleaner way to implement this.