### PR TITLE
fix(rename): limit thread names to less than 100 characters

### DIFF
--- a/src/commands/title.ts
+++ b/src/commands/title.ts
@@ -79,6 +79,7 @@ export const command: NeedleCommand = {
 			return interactionReply(interaction, getMessage("ERR_ONLY_THREAD_OWNER", interaction.id));
 		}
 
+		// TODO- djs 13.9 should support string builder max_lengths (as dapi does currently)
 		if (newThreadName.length > 100) {
 			return interactionReply(interaction, getMessage("ERR_THREAD_NAME_TOO_LONG", interaction.id));
 		}

--- a/src/commands/title.ts
+++ b/src/commands/title.ts
@@ -79,6 +79,10 @@ export const command: NeedleCommand = {
 			return interactionReply(interaction, getMessage("ERR_ONLY_THREAD_OWNER", interaction.id));
 		}
 
+		if (newThreadName.length > 100) {
+			return interactionReply(interaction, getMessage("ERR_THREAD_NAME_TOO_LONG", interaction.id));
+		}
+
 		await setThreadName(channel, newThreadName);
 		await interactionReply(interaction, "Success!");
 	},

--- a/src/commands/title.ts
+++ b/src/commands/title.ts
@@ -34,7 +34,7 @@ export const command: NeedleCommand = {
 			.setName("title")
 			.setDescription("Sets the title of a thread")
 			.addStringOption(option => {
-				return option.setName("value").setDescription("The new title of the thread").setRequired(true);
+				return option.setName("value").setDescription("The new title of the thread").setMinLength(0).setMaxLength(100).setRequired(true);
 			})
 			.toJSON();
 	},
@@ -79,7 +79,6 @@ export const command: NeedleCommand = {
 			return interactionReply(interaction, getMessage("ERR_ONLY_THREAD_OWNER", interaction.id));
 		}
 
-		// TODO- djs 13.9 should support string builder max_lengths (as dapi does currently)
 		if (newThreadName.length > 100) {
 			return interactionReply(interaction, getMessage("ERR_THREAD_NAME_TOO_LONG", interaction.id));
 		}

--- a/src/config.json
+++ b/src/config.json
@@ -15,7 +15,8 @@
 		"ERR_INSUFFICIENT_PERMS": "You do not have permission to perform this action.",
 		"ERR_CHANNEL_VISIBILITY": "The $CHANNEL channel is not visible to the bot. Change the permissions and try again.",
 		"ERR_CHANNEL_SLOWMODE": "The bot does not have permissions to Manage Threads in $CHANNEL. Change the permissions and try again.",
-		"ERR_AMBIGUOUS_THREAD_AUTHOR": "Could not determine the author of this thread, because the initial message was missing.",
+		"ERR_AMBIGUOUS_THREAD_AUTHOR": "Could not determine the author of this thread, because the initial message was missing.", 
+		"ERR_THREAD_NAME_TOO_LONG": "The new thread name cannot exceed 100 characters!",
 
 		"SUCCESS_THREAD_CREATE": "Thread automatically created by $USER in $CHANNEL.",
 		"SUCCESS_THREAD_ARCHIVE_IMMEDIATE": "Thread was archived by $USER. Anyone can send a message to unarchive it.",

--- a/src/types/needleConfig.ts
+++ b/src/types/needleConfig.ts
@@ -27,6 +27,7 @@ export interface NeedleConfig {
 		ERR_CHANNEL_VISIBILITY?: string;
 		ERR_CHANNEL_SLOWMODE?: string;
 		ERR_AMBIGUOUS_THREAD_AUTHOR?: string;
+		ERR_THREAD_NAME_TOO_LONG?: string;
 
 		SUCCESS_THREAD_CREATE?: string;
 		SUCCESS_THREAD_ARCHIVE_IMMEDIATE?: string;


### PR DESCRIPTION
Fixes #173 by enforcing string limits before renaming the thread.