### PR TITLE
chore(*): read from config before setting default values

### DIFF
--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -117,18 +117,18 @@ export const command: NeedleCommand = {
 								{ name: "⌛ Archive after 1 hour of inactivity", value: "slow" }
 							);
 					})
-					.addStringOption(option => {
+					.addIntegerOption(option => {
 						return option
 							.setName("slowmode")
 							.setDescription("The default slowmode option for new threads")
 							.addChoices(
-								{ name: "Off (DEFAULT)", value: "0" },
-								{ name: "30 seconds", value: "30" },
-								{ name: "1 minute", value: "60" },
-								{ name: "5 minutes", value: "300" },
-								{ name: "15 minutes", value: "900" },
-								{ name: "1 hour", value: "3600" },
-								{ name: "6 hours", value: "21600" }
+								{ name: "Off (DEFAULT)", value: 0 },
+								{ name: "30 seconds", value: 30 },
+								{ name: "1 minute", value: 60 },
+								{ name: "5 minutes", value: 300 },
+								{ name: "15 minutes", value: 900 },
+								{ name: "1 hour", value: 3600 },
+								{ name: "6 hours", value: 21600 }
 							);
 					})
 					.addStringOption(option => {
@@ -229,7 +229,7 @@ async function configureAutothreading(interaction: ChatInputCommandInteraction):
 	const enabled = interaction.options.getBoolean("enabled") ?? channelConfiguration != null
 	const customMessage = interaction.options.getString("custom-message") ?? channelConfiguration?.messageContent ?? "";
 	const includeBots = interaction.options.getBoolean("include-bots") ?? channelConfiguration?.includeBots ?? false;
-	const slowmode = parseInt(interaction.options.getString("slowmode") ?? "0");
+	const slowmode = interaction.options.getInteger("slowmode") ?? channelConfiguration?.slowmode ?? 0;
 
 	const archiveImmediately = interaction.options.getString("archive-behavior") != null
 		? interaction.options.getString("archive-behavior") !== "slow"

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -220,7 +220,7 @@ function configureMessage(interaction: ChatInputCommandInteraction): ExecuteResu
 }
 
 async function configureAutothreading(interaction: ChatInputCommandInteraction): ExecuteResult {
-	const guildCurrentConfiguration = readConfigFromFile(interaction.guildId!);
+	const guildCurrentConfiguration = getConfig(interaction.guildId!);
 
 	const channel = interaction.options.getChannel("channel") as TextBasedChannel;
 

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -221,13 +221,14 @@ function configureMessage(interaction: ChatInputCommandInteraction): ExecuteResu
 
 async function configureAutothreading(interaction: ChatInputCommandInteraction): ExecuteResult {
 	const guildCurrentConfiguration = readConfigFromFile(interaction.guildId!);
+
 	const channel = interaction.options.getChannel("channel") as TextBasedChannel;
 
 	const channelConfiguration = guildCurrentConfiguration?.threadChannels?.filter(c => c.channelId === channel?.id)[0];
 
 	const enabled = interaction.options.getBoolean("enabled") ?? channelConfiguration != null
-	const customMessage = interaction.options.getString("custom-message") ?? channelConfiguration?.messageContent;
-	const includeBots = interaction.options.getBoolean("include-bots") ?? channelConfiguration?.includeBots;
+	const customMessage = interaction.options.getString("custom-message") ?? channelConfiguration?.messageContent ?? "";
+	const includeBots = interaction.options.getBoolean("include-bots") ?? channelConfiguration?.includeBots ?? false;
 	const slowmode = parseInt(interaction.options.getString("slowmode") ?? "0");
 
 	const archiveImmediately = interaction.options.getString("archive-behavior") != null

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -26,7 +26,6 @@ import {
 	emojisEnabled,
 	enableAutothreading,
 	getConfig,
-	readConfigFromFile,
 	resetConfigToDefault,
 	setEmojisEnabled,
 	setMessage,

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -158,7 +158,7 @@ export function deleteConfigsFromUnknownServers(client: Client): void {
 	});
 }
 
-function readConfigFromFile(guildId: string): NeedleConfig | undefined {
+export function readConfigFromFile(guildId: string): NeedleConfig | undefined {
 	const path = getGuildConfigPath(guildId);
 	if (!fs.existsSync(path)) return undefined;
 

--- a/src/helpers/configHelpers.ts
+++ b/src/helpers/configHelpers.ts
@@ -158,7 +158,7 @@ export function deleteConfigsFromUnknownServers(client: Client): void {
 	});
 }
 
-export function readConfigFromFile(guildId: string): NeedleConfig | undefined {
+function readConfigFromFile(guildId: string): NeedleConfig | undefined {
 	const path = getGuildConfigPath(guildId);
 	if (!fs.existsSync(path)) return undefined;
 


### PR DESCRIPTION
This fixes #114 by reading the config from disk before setting the default values.

This makes the code much more verbose, but it is a necessary evil to ensure that the user is upserting and not rewriting.