### PR TITLE
✨ Enable internal sharding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 	const CLIENT = new Client({
 		intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
+		shards: "auto",
 		presence: {
 			activities: [
 				{


### PR DESCRIPTION
From https://discordjs.guide/sharding/#how-does-sharding-work:
> Apart from ShardingManager, discord.js also supports a sharding mode known as Internal sharding. Internal sharding creates multiple websocket connections from the same process, and does not require major code changes. To enable it, simply pass shards: 'auto' as ClientOptions to the Client constructor. However, internal sharding is not ideal for bigger bots due to high memory usage of the single main process and will not be further discussed in this guide.

I looked around in the Discord.js guide and it seems like internal sharding should work fine up to 20k servers. We're currently on 2k. I'm not going to implement stuff with ShardingManager as it seems that it will be replaced soon:tm: by a new sharding system.