### PR TITLE
🕵️ Simplify privacy policy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,36 +1,5 @@
 # Privacy policy
 
-Needle has never and will never collect any personal data. This includes message content, names, IP-adresses, time stamps, member information, etc.
+<sup>Feel free to contact us at [privacy@needle.gg](mailto:privacy@needle.gg) if you have any questions about this privacy policy.<br>Last updated and effective: August 29, 2022 - <a href="https://github.com/MarcusOtter/discord-needle/commits/stable/PRIVACY_POLICY.md">see update history</a></sup>
 
-## What we collect
-
-We do not collect any data automatically. The only data we collect is user-provided guild configuration data for Needle. When this is provided (by invoking configuration commands), we may collect:
-
--   Guild IDs
--   Channel IDs
--   Custom responses
--   Which features are enabled or disabled
-
-## Data retention
-
-The data is deleted from the main disk when one of the following occurs:
-
--   Needle is removed from the guild
--   A user successfully invokes the `/configure default` command
--   A user indicates to us by other means that they want their data deleted
-
-The data may persist in full-disk copies made for backup-purposes for up to 7 days after it was originally deleted.
-
-## Where information is processed
-
-Needle is hosted on a data center in Helsinki, Finland by [Hetzner Online GmbH](https://www.hetzner.com/legal/privacy-policy). The bot communicates with [Discord](https://discord.com/privacy)'s API to interact with users.
-
-## Changes to this privacy policy
-
-We reserve the right to update this privacy policy at any time, with at least 24 hours prior notice in the [Discord support server](https://needle.gg/chat). Your continued use of Needle after the changes have been applied indicates that you agree with the revised privacy policy.
-
-## Contact
-
-Feel free to contact us at [privacy@needle.gg](mailto:privacy@needle.gg) if you have any questions about this privacy policy.
-
-<sub>Last updated and effective: February 3, 2022 - <a href="https://github.com/MarcusOtter/discord-needle/commits/main/PRIVACY_POLICY.md">see update history</a></sub>
+**Needle has never and will never collect any personal data**. 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -2,4 +2,4 @@
 
 <sup>Feel free to contact us at [privacy@needle.gg](mailto:privacy@needle.gg) if you have any questions about this privacy policy.<br>Last updated and effective: August 29, 2022 - <a href="https://github.com/MarcusOtter/discord-needle/commits/stable/PRIVACY_POLICY.md">see update history</a></sup>
 
-**Needle has never and will never collect any personal data**. 
+**Needle has never and will never collect any personal data**.


### PR DESCRIPTION
This document previously contained unnecessary information. Since Needle does not collect any personal data, we technically don't even need a privacy policy. But it's a requirement by Discord, so we'll leave it like this.