### PR TITLE
🐛 Use .cleanContent instead of .content

### DIFF
--- a/src/services/ThreadCreationService.ts
+++ b/src/services/ThreadCreationService.ts
@@ -144,7 +144,7 @@ export default class InformationService {
 			}\n\n`;
 		}
 
-		return variables.removeFrom(message.content + "\n\n" + embedContent);
+		return variables.removeFrom(message.cleanContent + "\n\n" + embedContent);
 	}
 
 	private async getButtonRow(


### PR DESCRIPTION
This pull request replaces `message.content` with[ `message.cleanContent`](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=cleanContent) in the thread creation process, which resolves mentions to their actual text.

Only needed to change one line, which _feels_ like it shouldn't "just work", but I think it does.

* Closes #347