### PR TITLE
Add fallback of attachment name if there is no message/embed content

### DIFF
--- a/src/services/ThreadCreationService.ts
+++ b/src/services/ThreadCreationService.ts
@@ -182,9 +182,9 @@ export default class ThreadCreationService {
 			);
 		}
 
-		const firstAttachment = message.attachments.first()
+		const firstAttachment = message.attachments.first();
 		if (!message.cleanContent && !embedCleanContent && firstAttachment) {
-			return firstAttachment.name.split(".")[0]
+			return firstAttachment.name.split(".")[0];
 		}
 
 		return variables.removeFrom(message.cleanContent + "\n\n" + embedCleanContent);

--- a/src/services/ThreadCreationService.ts
+++ b/src/services/ThreadCreationService.ts
@@ -182,6 +182,11 @@ export default class ThreadCreationService {
 			);
 		}
 
+		const firstAttachment = message.attachments.first()
+		if (!message.cleanContent && !embedCleanContent && firstAttachment) {
+			return firstAttachment.name.split(".")[0]
+		}
+
 		return variables.removeFrom(message.cleanContent + "\n\n" + embedCleanContent);
 	}
 


### PR DESCRIPTION
Closes #506 

I didn't end up adding a variable because `MessageVariables.replace` would then require the whole message to be passed, which is not ideal...