### PR TITLE
Ignore markdown in thread title

### DIFF
--- a/src/services/ThreadCreationService.ts
+++ b/src/services/ThreadCreationService.ts
@@ -182,7 +182,22 @@ export default class ThreadCreationService {
 			);
 		}
 
-		return variables.removeFrom(message.cleanContent + "\n\n" + embedCleanContent);
+		let content = message.cleanContent + "\n\n" + embedCleanContent;
+
+		content = content
+			.replace(/^#{1,3} /gm, "")
+			.replace(/^-# /gm, "")
+			.replace(/^ *[-*] (.*)/gm, "$1")
+			.replace(/(\*+)([^*\n]+)\1/gm, "$2")
+			.replace(/(_+)([^_\n]+)\1 /gm, "$2")
+			.replace(/\[(.+)\]\(.+\)/gm, "$1")
+			.replace(/~~(.+)~~/gm, "$1")
+			.replace(/\|\|.+\|\|/gm, "")
+			.replace(/(?:>|>>>) (.+)/gm, "$1")
+			.replace(/`([^`\n]+)`/gm, "$1")
+			.replace(/```\w*\n(.*)```/gms, "$1");
+
+		return variables.removeFrom(content);
 	}
 
 	private async getButtonRow(


### PR DESCRIPTION
This should be a reasonably simple way of excluding most markdown without adding a dependency.

I've tested this but I'm not the best at regex so I can't guarantee it's non-exhaustive 😅 

The only issue I found is that it's currently triggering for stuff inside codeblocks - if you're okay with it I just *won't* have anything inside a codeblock in the title? Unless you can think of a better way.

I've also had spoilers not show in the title to not spoil them... let me know if you want that reverted.